### PR TITLE
Fix broken logo image in production

### DIFF
--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import logoUrl from '/home/sam/code/sjapaget/react/projects/escape-game-react/src/assets/Esc-Logo-8bit-colour.png'
 
 const Nav = (props) => {
   const { scene } = props;
   return (
     <div className='flex flex-row justify-between items-center bg-orange-500 text-neutral-100'>
-      <img className='w-12 m-1' src="/src/assets/Esc-Logo-8bit.png" alt="logo" />
+      <img className='w-12 m-1' src={logoUrl} alt="logo" />
       <ul className='flex flex-row'>
         <li className='px-4'>{scene}/6</li>
         <li className='px-4'>Time Left: 60:00</li>


### PR DESCRIPTION
**Problem**
Previously the logo image in the navbar was not loading correctly in production - the src path was not leading to the image file once the build had been run by vite. 

**Solution**
This was fixed by removing the path which had been hard-coded for the src attribute and replacing it with an import statement that assigns the path to a variable. This variable is then used in the jsx of the navbar to assign the src attribute. 

This way when we run the build process with vite the correct asset paths are assigned and the image is properly loaded.